### PR TITLE
Handle backend validation errors on login form

### DIFF
--- a/Tikit/APIError.swift
+++ b/Tikit/APIError.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Generic API error response that can contain both field-specific validation errors and a general message.
+struct APIErrorResponse: Codable {
+    let message: String?
+    let errors: [String: [String]]?
+}
+
+extension APIErrorResponse {
+    /// Convenience computed property that maps each field to its first error message.
+    var fieldErrors: [String: String] {
+        errors?.mapValues { $0.first ?? "" } ?? [:]
+    }
+}

--- a/Tikit/LoginView.swift
+++ b/Tikit/LoginView.swift
@@ -139,8 +139,13 @@ struct LoginView: View {
         passwordError = password.isEmpty ? "Contraseña requerida" : nil
         guard emailError == nil && passwordError == nil else { return }
         isLoading = true
-        if let error = await session.login(email: email, password: password) {
-            showToast(error)
+        if let apiError = await session.login(email: email, password: password) {
+            let fieldErrors = apiError.fieldErrors
+            emailError = fieldErrors["email"]
+            passwordError = fieldErrors["password"]
+            if fieldErrors.isEmpty {
+                showToast(apiError.message ?? "Error del servidor")
+            }
         }
         isLoading = false
     }


### PR DESCRIPTION
## Summary
- Parse backend validation errors with new `APIErrorResponse`
- Return `APIErrorResponse` from `SessionManager.login`
- Highlight login fields and show messages from backend validation

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68b567312bac832c80fb32144ea5c9cf