### PR TITLE
Add tab bar with profile and logout

### DIFF
--- a/Tikit/HomeView.swift
+++ b/Tikit/HomeView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        NavigationView {
+            Text("Main Screen")
+                .navigationTitle("Home")
+        }
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/Tikit/MainView.swift
+++ b/Tikit/MainView.swift
@@ -2,10 +2,19 @@ import SwiftUI
 
 struct MainView: View {
     var body: some View {
-        Text("Main Screen")
+        TabView {
+            HomeView()
+                .tabItem {
+                    Label("Home", systemImage: "house")
+                }
+            ProfileView()
+                .tabItem {
+                    Label("Mi cuenta", systemImage: "person")
+                }
+        }
     }
 }
 
 #Preview {
-    MainView()
+    MainView().environmentObject(SessionManager())
 }

--- a/Tikit/ProfileView.swift
+++ b/Tikit/ProfileView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct ProfileView: View {
+    @EnvironmentObject var session: SessionManager
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                Image(systemName: "person.circle.fill")
+                    .resizable()
+                    .frame(width: 100, height: 100)
+                    .foregroundColor(.gray)
+                    .padding(.top, 40)
+                Form {
+                    Section {
+                        profileRow(title: "Nombre", value: "John")
+                        profileRow(title: "Apellido", value: "Doe")
+                        profileRow(title: "Email", value: "john.doe@example.com")
+                    }
+                }
+                .frame(maxHeight: 250)
+                Spacer()
+                Button(action: {
+                    session.logout()
+                }) {
+                    Text("Salir")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.red)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+            }
+            .padding()
+            .navigationTitle("Mi cuenta")
+        }
+    }
+
+    @ViewBuilder
+    private func profileRow(title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value).foregroundColor(.secondary)
+        }
+    }
+}
+
+#Preview {
+    ProfileView().environmentObject(SessionManager())
+}

--- a/Tikit/SessionManager.swift
+++ b/Tikit/SessionManager.swift
@@ -129,4 +129,13 @@ class SessionManager: ObservableObject {
             return error.localizedDescription
         }
     }
+
+    @MainActor
+    func logout() {
+        token = nil
+        refreshToken = nil
+        UserDefaults.standard.removeObject(forKey: tokenKey)
+        UserDefaults.standard.removeObject(forKey: refreshTokenKey)
+        isLoggedIn = false
+    }
 }


### PR DESCRIPTION
## Summary
- Add TabView with Home and Mi cuenta tabs
- Implement simple profile screen with placeholder data and logout button
- Provide logout method in SessionManager and home view

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b56a728b00832cad80a45f834b50df