### PR TITLE
feat: display paginated events on main screen

### DIFF
--- a/Tikit/Event.swift
+++ b/Tikit/Event.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Event: Codable, Identifiable {
+struct Event: Codable, Identifiable, Equatable {
     let id: Int
     let name: String
     let accessType: String

--- a/Tikit/Event.swift
+++ b/Tikit/Event.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct Event: Codable, Identifiable {
+    let id: Int
+    let name: String
+    let accessType: String
+    let isActive: Bool
+    let createdAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case accessType
+        case isActive
+        case createdAt
+    }
+
+    var createdDateFormatted: String {
+        let formatter = ISO8601DateFormatter()
+        guard let date = formatter.date(from: createdAt) else { return createdAt }
+        let display = DateFormatter()
+        display.dateStyle = .medium
+        display.timeStyle = .short
+        return display.string(from: date)
+    }
+}
+
+struct EventsResponse: Codable {
+    let data: [Event]
+    let pagination: Pagination
+}
+
+struct Pagination: Codable {
+    let currentPage: Int
+    let perPage: Int
+    let totalItems: Int
+    let totalPages: Int
+
+    enum CodingKeys: String, CodingKey {
+        case currentPage = "current_page"
+        case perPage = "per_page"
+        case totalItems = "total_items"
+        case totalPages = "total_pages"
+    }
+}

--- a/Tikit/EventsViewModel.swift
+++ b/Tikit/EventsViewModel.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+@MainActor
+class EventsViewModel: ObservableObject {
+    @Published var events: [Event] = []
+    @Published var isLoading = false
+    private var currentPage = 1
+    private var totalPages = 1
+
+    func loadMoreIfNeeded(currentItem item: Event?, token: String?) async {
+        guard let token = token else { return }
+        if item == nil || item == events.last {
+            await fetchEvents(token: token)
+        }
+    }
+
+    private func fetchEvents(token: String) async {
+        guard !isLoading, currentPage <= totalPages else { return }
+        isLoading = true
+        let urlString = "https://tikit.cl/api/events?page=\(currentPage)&query=&limit=10&order=id:DESC&filter=[]"
+        guard let url = URL(string: urlString) else { isLoading = false; return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                isLoading = false
+                return
+            }
+            let result = try JSONDecoder().decode(EventsResponse.self, from: data)
+            events.append(contentsOf: result.data)
+            currentPage += 1
+            totalPages = result.pagination.totalPages
+        } catch {
+            // handle error if necessary
+        }
+        isLoading = false
+    }
+}

--- a/Tikit/HomeView.swift
+++ b/Tikit/HomeView.swift
@@ -1,14 +1,61 @@
 import SwiftUI
 
 struct HomeView: View {
+    @EnvironmentObject var session: SessionManager
+    @StateObject private var viewModel = EventsViewModel()
+
     var body: some View {
         NavigationView {
-            Text("Main Screen")
-                .navigationTitle("Home")
+            List {
+                ForEach(viewModel.events) { event in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(event.name)
+                            .font(.headline)
+                        HStack {
+                            ChipView(text: event.accessType == "ACCESS_TYPE_FREE" ? "Entrada libre" : "Evento pago",
+                                     color: event.accessType == "ACCESS_TYPE_FREE" ? .green : .red)
+                            ChipView(text: event.isActive ? "SI" : "NO",
+                                     color: event.isActive ? .green : .red)
+                        }
+                        Text("Creado: \(event.createdDateFormatted)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .onAppear {
+                        Task {
+                            await viewModel.loadMoreIfNeeded(currentItem: event, token: session.token)
+                        }
+                    }
+                }
+                if viewModel.isLoading {
+                    HStack { Spacer(); ProgressView(); Spacer() }
+                }
+            }
+            .listStyle(.plain)
+            .navigationTitle("Eventos")
+            .onAppear {
+                Task {
+                    await viewModel.loadMoreIfNeeded(currentItem: nil, token: session.token)
+                }
+            }
         }
     }
 }
 
+struct ChipView: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .padding(6)
+            .background(color.opacity(0.2))
+            .foregroundColor(color)
+            .clipShape(Capsule())
+    }
+}
+
 #Preview {
-    HomeView()
+    HomeView().environmentObject(SessionManager())
 }

--- a/Tikit/MainView.swift
+++ b/Tikit/MainView.swift
@@ -5,7 +5,7 @@ struct MainView: View {
         TabView {
             HomeView()
                 .tabItem {
-                    Label("Home", systemImage: "house")
+                    Label("Eventos", systemImage: "list.bullet")
                 }
             ProfileView()
                 .tabItem {


### PR DESCRIPTION
## Summary
- show user's events with access type, active state, and creation date
- fetch events from API with auth header and paging
- adjust main tab labels

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68b58147bfa8832cb8613b840095bd72