### PR TITLE
Add brand color palette and apply to login button

### DIFF
--- a/Tikit/Colors.swift
+++ b/Tikit/Colors.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+extension Color {
+    /// Primary brand color (#B6287E)
+    static let brandPrimary = Color(red: 182/255.0, green: 40/255.0, blue: 126/255.0)
+    /// Secondary brand color (#5E38E2)
+    static let brandSecondary = Color(red: 94/255.0, green: 56/255.0, blue: 226/255.0)
+}

--- a/Tikit/LoginView.swift
+++ b/Tikit/LoginView.swift
@@ -101,7 +101,7 @@ struct LoginView: View {
                         }
                         .frame(maxWidth: .infinity)
                         .padding()
-                        .background(Color.blue)
+                        .background(Color.brandPrimary)
                         .foregroundColor(.white)
                         .cornerRadius(8)
                         .disabled(isLoading)


### PR DESCRIPTION
## Summary
- Define reusable brand primary (#B6287E) and secondary (#5E38E2) colors.
- Use the primary brand color for the “Iniciar sesión” button.

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b58e6a3140832cac88251d39834466