### PR TITLE
Add sessions list and search in events screen

### DIFF
--- a/Tikit/Event.swift
+++ b/Tikit/Event.swift
@@ -43,3 +43,43 @@ struct Pagination: Codable {
         case totalPages = "total_pages"
     }
 }
+
+struct EventDetailResponse: Codable {
+    let data: EventDetail
+}
+
+struct EventDetail: Codable {
+    let id: Int
+    let name: String
+    let sessions: [EventSession]
+}
+
+struct EventSession: Codable, Identifiable {
+    let id: Int
+    let startsAt: String
+    let endsAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case startsAt = "starts_at"
+        case endsAt = "ends_at"
+    }
+
+    var startDateFormatted: String {
+        let formatter = ISO8601DateFormatter()
+        guard let date = formatter.date(from: startsAt) else { return startsAt }
+        let display = DateFormatter()
+        display.dateStyle = .medium
+        display.timeStyle = .short
+        return display.string(from: date)
+    }
+
+    var endDateFormatted: String {
+        let formatter = ISO8601DateFormatter()
+        guard let date = formatter.date(from: endsAt) else { return endsAt }
+        let display = DateFormatter()
+        display.dateStyle = .medium
+        display.timeStyle = .short
+        return display.string(from: date)
+    }
+}

--- a/Tikit/HomeView.swift
+++ b/Tikit/HomeView.swift
@@ -3,23 +3,31 @@ import SwiftUI
 struct HomeView: View {
     @EnvironmentObject var session: SessionManager
     @StateObject private var viewModel = EventsViewModel()
+    @State private var searchText = ""
+
+    private var filteredEvents: [Event] {
+        if searchText.isEmpty { return viewModel.events }
+        return viewModel.events.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
 
     var body: some View {
         NavigationView {
             List {
-                ForEach(viewModel.events) { event in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(event.name)
-                            .font(.headline)
-                        HStack {
-                            ChipView(text: event.accessType == "ACCESS_TYPE_FREE" ? "Entrada libre" : "Evento pago",
-                                     color: event.accessType == "ACCESS_TYPE_FREE" ? .green : .red)
-                            ChipView(text: event.isActive ? "SI" : "NO",
-                                     color: event.isActive ? .green : .red)
+                ForEach(filteredEvents) { event in
+                    NavigationLink(destination: SessionsView(event: event)) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(event.name)
+                                .font(.headline)
+                            HStack {
+                                ChipView(text: event.accessType == "ACCESS_TYPE_FREE" ? "Entrada libre" : "Evento pago",
+                                         color: event.accessType == "ACCESS_TYPE_FREE" ? .green : .red)
+                                ChipView(text: event.isActive ? "SI" : "NO",
+                                         color: event.isActive ? .green : .red)
+                            }
+                            Text("Creado: \(event.createdDateFormatted)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
                         }
-                        Text("Creado: \(event.createdDateFormatted)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
                     }
                     .onAppear {
                         Task {
@@ -32,6 +40,7 @@ struct HomeView: View {
                 }
             }
             .listStyle(.plain)
+            .searchable(text: $searchText)
             .navigationTitle("Eventos")
             .onAppear {
                 Task {
@@ -53,6 +62,50 @@ struct ChipView: View {
             .background(color.opacity(0.2))
             .foregroundColor(color)
             .clipShape(Capsule())
+    }
+}
+
+struct SessionsView: View {
+    let event: Event
+    @EnvironmentObject var session: SessionManager
+    @State private var sessions: [EventSession] = []
+    @State private var isLoading = false
+
+    var body: some View {
+        List(sessions) { item in
+            VStack(alignment: .leading) {
+                Text("Inicio: \(item.startDateFormatted)")
+                Text("Fin: \(item.endDateFormatted)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .navigationTitle("Sesiones")
+        .onAppear {
+            Task { await fetchSessions() }
+        }
+    }
+
+    private func fetchSessions() async {
+        guard let token = session.token, !isLoading else { return }
+        isLoading = true
+        let urlString = "https://tikit.cl/api/events/\(event.id)"
+        guard let url = URL(string: urlString) else { isLoading = false; return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                isLoading = false
+                return
+            }
+            let result = try JSONDecoder().decode(EventDetailResponse.self, from: data)
+            sessions = result.data.sessions
+        } catch {
+            // handle error if needed
+        }
+        isLoading = false
     }
 }
 


### PR DESCRIPTION
## Summary
- enable searching and filtering of events
- navigate into an event to display its sessions
- add models and API call for event sessions

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b58fdcc7a0832c9da3b3f01dc30e1c