### PR TITLE
Fetch and display event sessions with navigation

### DIFF
--- a/Tikit/Event.swift
+++ b/Tikit/Event.swift
@@ -61,14 +61,31 @@ struct EventSession: Codable, Identifiable {
     let endTime: String?
 
     var dateRangeFormatted: String? {
-        let startComponents = [startDate, startTime].compactMap { $0 }.joined(separator: " ")
-        let endComponents = [endDate, endTime].compactMap { $0 }.joined(separator: " ")
-        if !startComponents.isEmpty && !endComponents.isEmpty {
-            return "\(startComponents) - \(endComponents)"
-        } else if !startComponents.isEmpty {
-            return startComponents
-        } else if !endComponents.isEmpty {
-            return endComponents
+        let inputFormatter = ISO8601DateFormatter()
+        let altFormatter = DateFormatter()
+        altFormatter.dateFormat = "yyyy-MM-dd"
+        let displayFormatter = DateFormatter()
+        displayFormatter.dateFormat = "dd/MM/yyyy"
+
+        func formattedDate(from string: String?) -> String? {
+            guard let string = string else { return nil }
+            if let date = inputFormatter.date(from: string) {
+                return displayFormatter.string(from: date)
+            }
+            if let date = altFormatter.date(from: string) {
+                return displayFormatter.string(from: date)
+            }
+            return nil
+        }
+
+        let start = formattedDate(from: startDate)
+        let end = formattedDate(from: endDate)
+        if let start = start, let end = end {
+            return "\(start) - \(end)"
+        } else if let start = start {
+            return start
+        } else if let end = end {
+            return end
         }
         return nil
     }

--- a/Tikit/Event.swift
+++ b/Tikit/Event.swift
@@ -44,42 +44,32 @@ struct Pagination: Codable {
     }
 }
 
-struct EventDetailResponse: Codable {
-    let data: EventDetail
-}
-
-struct EventDetail: Codable {
-    let id: Int
-    let name: String
+struct SessionsResponse: Codable {
     let sessions: [EventSession]
 }
 
 struct EventSession: Codable, Identifiable {
     let id: Int
-    let startsAt: String
-    let endsAt: String
+    let name: String
+    let description: String?
+    let createdAt: String?
+    let updatedAt: String?
+    let isDefault: Bool?
+    let startDate: String?
+    let startTime: String?
+    let endDate: String?
+    let endTime: String?
 
-    enum CodingKeys: String, CodingKey {
-        case id
-        case startsAt = "starts_at"
-        case endsAt = "ends_at"
-    }
-
-    var startDateFormatted: String {
-        let formatter = ISO8601DateFormatter()
-        guard let date = formatter.date(from: startsAt) else { return startsAt }
-        let display = DateFormatter()
-        display.dateStyle = .medium
-        display.timeStyle = .short
-        return display.string(from: date)
-    }
-
-    var endDateFormatted: String {
-        let formatter = ISO8601DateFormatter()
-        guard let date = formatter.date(from: endsAt) else { return endsAt }
-        let display = DateFormatter()
-        display.dateStyle = .medium
-        display.timeStyle = .short
-        return display.string(from: date)
+    var dateRangeFormatted: String? {
+        let startComponents = [startDate, startTime].compactMap { $0 }.joined(separator: " ")
+        let endComponents = [endDate, endTime].compactMap { $0 }.joined(separator: " ")
+        if !startComponents.isEmpty && !endComponents.isEmpty {
+            return "\(startComponents) - \(endComponents)"
+        } else if !startComponents.isEmpty {
+            return startComponents
+        } else if !endComponents.isEmpty {
+            return endComponents
+        }
+        return nil
     }
 }

--- a/Tikit/HomeView.swift
+++ b/Tikit/HomeView.swift
@@ -73,11 +73,16 @@ struct SessionsView: View {
 
     var body: some View {
         List(sessions) { item in
-            VStack(alignment: .leading) {
-                Text("Inicio: \(item.startDateFormatted)")
-                Text("Fin: \(item.endDateFormatted)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+            NavigationLink(destination: ScanView(session: item)) {
+                VStack(alignment: .leading) {
+                    Text(item.name)
+                        .font(.headline)
+                    if let range = item.dateRangeFormatted {
+                        Text(range)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
             }
         }
         .navigationTitle("Sesiones")
@@ -100,8 +105,8 @@ struct SessionsView: View {
                 isLoading = false
                 return
             }
-            let result = try JSONDecoder().decode(EventDetailResponse.self, from: data)
-            sessions = result.data.sessions
+            let result = try JSONDecoder().decode(SessionsResponse.self, from: data)
+            sessions = result.sessions
         } catch {
             // handle error if needed
         }

--- a/Tikit/ScanView.swift
+++ b/Tikit/ScanView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ScanView: View {
+    let session: EventSession
+
+    var body: some View {
+        Text("Scan for session: \(session.name)")
+            .navigationTitle("Escanear")
+    }
+}
+
+#Preview {
+    ScanView(session: EventSession(id: 0, name: "Demo", description: nil, createdAt: nil, updatedAt: nil, isDefault: nil, startDate: nil, startTime: nil, endDate: nil, endTime: nil))
+}


### PR DESCRIPTION
## Summary
- Decode event sessions from API response and include date range formatting
- Show session list with names and optional date range, each linking to a scan screen
- Add basic scan view placeholder for navigation

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b5976c8e58832ca2a3ae59ea1a96b9