### PR TITLE
Configure Google Sign-In URL scheme

### DIFF
--- a/Tikit.xcodeproj/project.pbxproj
+++ b/Tikit.xcodeproj/project.pbxproj
@@ -403,9 +403,10 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Tikit/Preview Content\"";
 				DEVELOPMENT_TEAM = 3833W4TFK6;
 				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+                                ENABLE_PREVIEWS = YES;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                INFOPLIST_FILE = Tikit/Info.plist;
+                                "INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
@@ -443,9 +444,10 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Tikit/Preview Content\"";
 				DEVELOPMENT_TEAM = 3833W4TFK6;
 				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+                                ENABLE_PREVIEWS = YES;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                INFOPLIST_FILE = Tikit/Info.plist;
+                                "INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;

--- a/Tikit/Info.plist
+++ b/Tikit/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>com.googleusercontent.apps.331974773758-ms75sk3bv25vkfm0a7qao8ft0ur1kvep</string>
+            </array>
+        </dict>
+    </array>
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>com.googleusercontent.apps.331974773758-ms75sk3bv25vkfm0a7qao8ft0ur1kvep</string>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add Info.plist with Google Sign-In URL scheme
- reference Info.plist in Xcode project settings

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b9b27b20832cb9ac4ad2c11c1a43